### PR TITLE
Support unknown CSS property values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lw-css-prefixer",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lw-css-prefixer",
-      "version": "0.0.1-alpha.1",
+      "version": "0.0.1-alpha.2",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "29.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lw-css-prefixer",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/plugin/alignContent.ts
+++ b/src/plugin/alignContent.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '../prefixer';
+import type { CSSDeclaration, Plugin } from '../prefixer';
 
 export const alignContent: Plugin = (property, value) => {
   if (property !== 'align-content') {
@@ -12,8 +12,14 @@ export const alignContent: Plugin = (property, value) => {
     'space-between': 'justify',
   };
 
-  return [
+  const toReturn: CSSDeclaration[] = [
     ['-webkit-align-content', value],
-    ['-ms-flex-line-pack', linePackReplacements[value] || value],
+    ['-ms-flex-line-pack', value],
   ];
+
+  if (typeof value === 'string' && linePackReplacements[value]) {
+    toReturn[1][1] = linePackReplacements[value];
+  }
+
+  return toReturn;
 };

--- a/src/plugin/cursor.ts
+++ b/src/plugin/cursor.ts
@@ -10,7 +10,7 @@ const prefixableValues: Record<string, 1> = {
 };
 
 export const cursor: Plugin = (property, value) => {
-  if (property !== 'cursor') {
+  if (typeof value !== 'string' || property !== 'cursor') {
     return;
   }
 

--- a/src/plugin/display.ts
+++ b/src/plugin/display.ts
@@ -6,7 +6,7 @@ const replacements: Record<string, string[]> = {
 };
 
 export const display: Plugin = (property, value) => {
-  if (property !== 'display') {
+  if (typeof value !== 'string' || property !== 'display') {
     return;
   }
 

--- a/src/plugin/flexDirection.ts
+++ b/src/plugin/flexDirection.ts
@@ -15,8 +15,8 @@ export const flexDirection: Plugin = (property, value) => {
     orientation = 'vertical';
     boxDirection = 'normal';
   } else {
-    orientation = value.indexOf('row') === -1 ? 'vertical' : 'horizontal';
-    boxDirection = value.indexOf('reverse') === -1 ? 'normal' : 'reverse';
+    orientation = (typeof value === 'string' && value.indexOf('row') === -1) ? 'vertical' : 'horizontal';
+    boxDirection = (typeof value === 'string' && value.indexOf('reverse') === -1) ? 'normal' : 'reverse';
   }
 
   return [

--- a/src/plugin/flexFlow.ts
+++ b/src/plugin/flexFlow.ts
@@ -30,8 +30,8 @@ export const flexFlow: Plugin = (property, value) => {
      * `flex-flow: row wrap-reverse` I'm _pretty_ sure this isn't meant
      * to have a box-orientation of reverse.
      */
-    orientation = value.indexOf('row') === -1 ? 'vertical' : 'horizontal';
-    boxDirection = value.indexOf('reverse') === -1 ? 'normal' : 'reverse';
+    orientation = (typeof value === 'string' && value.indexOf('row') === -1) ? 'vertical' : 'horizontal';
+    boxDirection = (typeof value === 'string' && value.indexOf('reverse') === -1) ? 'normal' : 'reverse';
   }
 
   return [

--- a/src/plugin/gradient.ts
+++ b/src/plugin/gradient.ts
@@ -6,7 +6,7 @@ import { Vendor } from '../Vendor';
 const regexp = /linear-gradient|radial-gradient|repeating-linear-gradient|repeating-radial-gradient/gi;
 
 export const gradient: Plugin = (property, value) => {
-  if (isVendorPrefixed(value) || !regexp.test(value)) {
+  if (isVendorPrefixed(value) || typeof value !== 'string' || !regexp.test(value)) {
     return;
   }
 

--- a/src/plugin/justifyContent.ts
+++ b/src/plugin/justifyContent.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from '../prefixer';
 
 export const justifyContent: Plugin = (property, value) => {
-  if (property !== 'justify-content') {
+  if (property !== 'justify-content' || !value || typeof value !== 'string') {
     return;
   }
 

--- a/src/plugin/size.ts
+++ b/src/plugin/size.ts
@@ -24,7 +24,10 @@ export const valueReplacements: Record<string, 1> = {
 
 export const size: Plugin = (property, value) => {
   const shouldPrefixProperty = !!propertiesThatPrefixProperty[property];
-  const shouldPrefixValue = !!propertiesThatPrefixValue[property] && !!valueReplacements[value];
+  
+  const shouldPrefixValue = !!propertiesThatPrefixValue[property] &&
+    typeof value === 'string' &&
+    !!valueReplacements[value];
 
   if (shouldPrefixProperty) {
     return addVendorPrefixes(property, Vendor.moz_wk).map((prefixedProperty) => [prefixedProperty, value]);

--- a/src/util/addVendorPrefixes.ts
+++ b/src/util/addVendorPrefixes.ts
@@ -1,3 +1,4 @@
+import { CSSPropertyValue } from '..';
 import { Vendor } from '../Vendor';
 import { vendorPrefixes } from './vendorPrefixes';
 
@@ -12,7 +13,7 @@ import { vendorPrefixes } from './vendorPrefixes';
  * addVendorPrefixes('hello-world', Vendor.none);
  * ```
  *
- * @param str - The value which we want to prefix with relevant standard
+ * @param propertyValue - The value which we want to prefix with relevant standard
  * vendor prefixes.
  * @param bitmask - The bitmask denoting the set of vendors we want to apply
  * prefixes for.
@@ -20,13 +21,13 @@ import { vendorPrefixes } from './vendorPrefixes';
  * vendor prefixes (note that this does **not** include the provided unprefixed
  * string).
  */
-export const addVendorPrefixes = (str: string, bitmask: Vendor) => {
+export const addVendorPrefixes = (propertyValue: CSSPropertyValue, bitmask: Vendor) => {
   const toReturn: string[] = [];
 
   Object.keys(vendorPrefixes).forEach((vendor) => {
     if (bitmask & Vendor[vendor as keyof typeof vendorPrefixes]) {
       toReturn.push(
-        `${vendorPrefixes[vendor as keyof typeof vendorPrefixes]}${str}`
+        `${vendorPrefixes[vendor as keyof typeof vendorPrefixes]}${propertyValue || ''}`
       );
     }
   });

--- a/src/util/isVendorPrefixed.ts
+++ b/src/util/isVendorPrefixed.ts
@@ -1,3 +1,4 @@
+import type { CSSPropertyValue } from '..';
 import { vendorPrefixes } from './vendorPrefixes';
 
 /**
@@ -12,16 +13,20 @@ import { vendorPrefixes } from './vendorPrefixes';
  * isVendorPrefixed('-moz-hello-world');
  * ```
  *
- * @param str - Property to check to see if it begins with a standard
+ * @param propertyValue - Property to check to see if it begins with a standard
  * vendor prefix.
  * @returns Is the provided property prefixed with a standard vendor prefix?
  */
-export const isVendorPrefixed = (str: string) => {
+export const isVendorPrefixed = (propertyValue: CSSPropertyValue) => {
+  if (!propertyValue || typeof propertyValue !== 'string') {
+    return false;
+  }
+
   const allPrefixes = Object.keys(vendorPrefixes).map(
     (pfx) => vendorPrefixes[pfx as keyof typeof vendorPrefixes],
   );
 
   const regexp = new RegExp(`^${allPrefixes.join('|')}`);
 
-  return regexp.test(str);
+  return regexp.test(propertyValue);
 };

--- a/src/util/makeFunctionPlugin.ts
+++ b/src/util/makeFunctionPlugin.ts
@@ -10,6 +10,7 @@ export const makeFunctionPlugin = (
 ): Plugin => (property, value) => {
   if (
     isVendorPrefixed(value) ||
+    typeof value !== 'string' ||
     value.indexOf(functionLiteralToFirstBracket) === -1
   ) {
     return;

--- a/test/assertTestCases.ts
+++ b/test/assertTestCases.ts
@@ -1,6 +1,6 @@
-import { CSSDeclaration, Plugin } from '../src/prefixer';
+import { CSSDeclaration, CSSPropertyValue, Plugin } from '../src/prefixer';
 
-type TestCases = [property: string, value: string, expect: CSSDeclaration[] | undefined][];
+type TestCases = [property: string, value: CSSPropertyValue, expect: CSSDeclaration[] | undefined][];
 
 export const assertTestCases = (plugin: Plugin, testCases: TestCases) => {
   test.each(testCases)(

--- a/test/plugin/alignContent.test.ts
+++ b/test/plugin/alignContent.test.ts
@@ -6,6 +6,9 @@ describe('plugin/alignContent', () => {
     alignContent,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['align-content', 'auto', [
         ['-webkit-align-content', 'auto'],
         ['-ms-flex-line-pack', 'auto'],

--- a/test/plugin/alignItems.test.ts
+++ b/test/plugin/alignItems.test.ts
@@ -6,6 +6,9 @@ describe('plugin/alignItems', () => {
     alignItems,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['align-items', 'auto', [
         ['-webkit-box-align', 'auto'],
         ['-webkit-align-items', 'auto'],

--- a/test/plugin/alignSelf.test.ts
+++ b/test/plugin/alignSelf.test.ts
@@ -6,6 +6,9 @@ describe('plugin/alignSelf', () => {
     alignSelf,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['align-self', 'auto', [
         ['-webkit-align-self', 'auto'],
         ['-ms-flex-item-align', 'auto'],

--- a/test/plugin/backgroundClip.test.ts
+++ b/test/plugin/backgroundClip.test.ts
@@ -5,6 +5,9 @@ describe('plugin/backgroundClip', () => {
   assertTestCases(
     backgroundClip,
     [
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['not-background-clip', 'text', undefined],
       ['background-clip', 'not-text', undefined],
       ['background-clip', 'text', [

--- a/test/plugin/border.test.ts
+++ b/test/plugin/border.test.ts
@@ -6,6 +6,9 @@ describe('plugin/border', () => {
     border,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['border-block-end', 'foo', [['-webkit-border-after', 'foo']]],
       ['border-block-end-color', 'foo', [['-webkit-border-after-color', 'foo']]],
       ['border-block-end-style', 'foo', [['-webkit-border-after-style', 'foo']]],

--- a/test/plugin/calc.test.ts
+++ b/test/plugin/calc.test.ts
@@ -5,6 +5,9 @@ describe('plugin/calc', () => {
   assertTestCases(
     calc,
     [
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['foo', '-webkit-calc(100% - 50px)', undefined],
       ['foo', 'calc(100% - 50px)', [
         ['foo', '-moz-calc(100% - 50px)'],

--- a/test/plugin/crossFade.test.ts
+++ b/test/plugin/crossFade.test.ts
@@ -5,6 +5,9 @@ describe('plugin/crossFade', () => {
   assertTestCases(
     crossFade,
     [
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['foo', '-webkit-cross-fade(100% - 50px)', undefined],
       ['foo', 'cross-fade(100% - 50px)', [
         ['foo', '-webkit-cross-fade(100% - 50px)'],

--- a/test/plugin/cursor.test.ts
+++ b/test/plugin/cursor.test.ts
@@ -6,6 +6,9 @@ describe('plugin/cursor', () => {
     cursor,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['cursor', 'inherit', undefined],
       ['cursor', 'initial', undefined],
       ['cursor', 'unset', undefined],

--- a/test/plugin/display.test.ts
+++ b/test/plugin/display.test.ts
@@ -6,6 +6,9 @@ describe('plugin/display', () => {
     display,
     [
       ['foo', 'flex', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['display', 'inherit', undefined],
       ['display', 'flex', [
         ['display', '-webkit-box'],

--- a/test/plugin/filter.test.ts
+++ b/test/plugin/filter.test.ts
@@ -6,6 +6,9 @@ describe('plugin/filter', () => {
     filter,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['foo', '-webkit-filter(url(\'foo.jpg\'))', undefined],
       ['foo', 'filter(url(\'foo.jpg\'))', [
         ['foo', '-webkit-filter(url(\'foo.jpg\'))'],

--- a/test/plugin/flexBasis.test.ts
+++ b/test/plugin/flexBasis.test.ts
@@ -6,6 +6,9 @@ describe('plugin/flexBasis', () => {
     flexBasis,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['flex-basis', '1', [
         ['-webkit-flex-basis', '1'],
         ['-ms-flex-preferred-size', '1'],

--- a/test/plugin/flexDirection.test.ts
+++ b/test/plugin/flexDirection.test.ts
@@ -6,6 +6,9 @@ describe('plugin/flexDirection', () => {
     flexDirection,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['flex-direction', 'auto', [
         ['-webkit-box-orient', 'vertical'],
         ['-webkit-box-direction', 'normal'],

--- a/test/plugin/flexFlow.test.ts
+++ b/test/plugin/flexFlow.test.ts
@@ -6,6 +6,9 @@ describe('plugin/flexFlow', () => {
     flexFlow,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['flex-flow', 'auto', [
         ['-webkit-box-orient', 'vertical'],
         ['-webkit-box-direction', 'normal'],

--- a/test/plugin/flexGrowShrink.test.ts
+++ b/test/plugin/flexGrowShrink.test.ts
@@ -6,6 +6,9 @@ describe('plugin/flexGrowShrink', () => {
     flexGrowShrink,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['flex-grow', '1', [
         ['-webkit-box-flex', '1'],
         ['-webkit-flex-grow', '1'],

--- a/test/plugin/gradient.test.ts
+++ b/test/plugin/gradient.test.ts
@@ -6,6 +6,9 @@ describe('plugin/gradient', () => {
     gradient,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['background-image', 'linear-gradient(red, yellow)', [
         ['background-image', '-moz-linear-gradient(red, yellow)'],
         ['background-image', '-webkit-linear-gradient(red, yellow)'],

--- a/test/plugin/imageSet.test.ts
+++ b/test/plugin/imageSet.test.ts
@@ -6,6 +6,9 @@ describe('plugin/imageSet', () => {
     imageSet,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['background-image', 'image-set(url(\'br.png\') 1x,url(\'tr.png\') 1x)', [
         ['background-image', '-webkit-image-set(url(\'br.png\') 1x,url(\'tr.png\') 1x)'],
       ]],

--- a/test/plugin/justifyContent.test.ts
+++ b/test/plugin/justifyContent.test.ts
@@ -6,6 +6,12 @@ describe('plugin/justifyContent', () => {
     justifyContent,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
+      ['justify-content', 100, undefined],
+      ['justify-content', null, undefined],
+      ['justify-content', undefined, undefined],
       ['justify-content', 'center', [
         ['-webkit-box-pack', 'center'],
         ['-webkit-justify-content', 'center'],

--- a/test/plugin/justifySelf.test.ts
+++ b/test/plugin/justifySelf.test.ts
@@ -6,6 +6,9 @@ describe('plugin/justifySelf', () => {
     justifySelf,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['justify-self', 'auto', [['-ms-grid-column-align', 'auto']]],
       ['justify-self', 'baseline', [['-ms-grid-column-align', 'baseline']]],
       ['justify-self', 'center', [['-ms-grid-column-align', 'center']]],

--- a/test/plugin/margin.test.ts
+++ b/test/plugin/margin.test.ts
@@ -6,6 +6,9 @@ describe('plugin/margin', () => {
     margin,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['margin-block-end', 'foo', [['-webkit-margin-after', 'foo']]],
       ['margin-block-start', 'foo', [['-webkit-margin-before', 'foo']]],
       ['margin-inline-end', 'foo', [

--- a/test/plugin/padding.test.ts
+++ b/test/plugin/padding.test.ts
@@ -6,6 +6,9 @@ describe('plugin/padding', () => {
     padding,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['padding-block-end', 'foo', [['-webkit-padding-after', 'foo']]],
       ['padding-block-start', 'foo', [['-webkit-padding-before', 'foo']]],
       ['padding-inline-end', 'foo', [

--- a/test/plugin/position.test.ts
+++ b/test/plugin/position.test.ts
@@ -6,6 +6,9 @@ describe('plugin/position', () => {
     position,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['position', 'absolute', undefined],
       ['position', 'inherit', undefined],
       ['position', 'sticky', [['position', '-webkit-sticky']]],

--- a/test/plugin/size.test.ts
+++ b/test/plugin/size.test.ts
@@ -6,6 +6,9 @@ describe('plugin/size', () => {
     size,
     [
       ['foo', 'bar', undefined],
+      ['foo', 100, undefined],
+      ['foo', null, undefined],
+      ['foo', undefined, undefined],
       ['height', '100px', undefined],
       ['height', 'inherit', undefined],
       ['height', 'unset', undefined],

--- a/test/prefixer.test.ts
+++ b/test/prefixer.test.ts
@@ -5,8 +5,21 @@ import { addVendorPrefixes } from '../src/util/addVendorPrefixes';
 describe('prefixer', () => {
   it('Returns property, value if no plugins or static prefixes', () => {
     const pfx = prefixer([], {});
+
     expect(pfx('foo', 'bar')).toEqual([
       ['foo', 'bar'],
+    ]);
+
+    expect(pfx('foo', 100)).toEqual([
+      ['foo', 100],
+    ]);
+
+    expect(pfx('foo', null)).toEqual([
+      ['foo', null],
+    ]);
+
+    expect(pfx('foo', undefined)).toEqual([
+      ['foo', undefined],
     ]);
   });
 
@@ -17,6 +30,24 @@ describe('prefixer', () => {
       ['-moz-foo', 'bar'],
       ['-ms-foo', 'bar'],
       ['foo', 'bar'],
+    ]);
+
+    expect(pfx('foo', 100)).toEqual([
+      ['-moz-foo', 100],
+      ['-ms-foo', 100],
+      ['foo', 100],
+    ]);
+
+    expect(pfx('foo', null)).toEqual([
+      ['-moz-foo', null],
+      ['-ms-foo', null],
+      ['foo', null],
+    ]);
+
+    expect(pfx('foo', undefined)).toEqual([
+      ['-moz-foo', undefined],
+      ['-ms-foo', undefined],
+      ['foo', undefined],
     ]);
   });
 
@@ -32,6 +63,21 @@ describe('prefixer', () => {
       ['-moz-foo', 'bar'],
       ['foo', 'bar'],
     ]);
+
+    expect(pfx('foo', 100)).toEqual([
+      ['-moz-foo', 100],
+      ['foo', 100],
+    ]);
+
+    expect(pfx('foo', null)).toEqual([
+      ['-moz-foo', null],
+      ['foo', null],
+    ]);
+
+    expect(pfx('foo', undefined)).toEqual([
+      ['-moz-foo', undefined],
+      ['foo', undefined],
+    ]);
   });
 
   it('Handles plugin returning no prefixes', () => {
@@ -41,6 +87,18 @@ describe('prefixer', () => {
 
     expect(pfx('foo', 'bar')).toEqual([
       ['foo', 'bar'],
+    ]);
+
+    expect(pfx('foo', 100)).toEqual([
+      ['foo', 100],
+    ]);
+
+    expect(pfx('foo', null)).toEqual([
+      ['foo', null],
+    ]);
+
+    expect(pfx('foo', undefined)).toEqual([
+      ['foo', undefined],
     ]);
   });
 });

--- a/test/prefixer.withAllPluginsAndPrefixes.test.ts
+++ b/test/prefixer.withAllPluginsAndPrefixes.test.ts
@@ -1,9 +1,9 @@
 import { plugins } from '../src/plugins';
-import { CSSDeclaration, prefixer } from '../src/prefixer';
+import { CSSDeclaration, CSSPropertyValue, prefixer } from '../src/prefixer';
 import { propertyPrefixes } from '../src/propertyPrefixes';
 import { assertTestCases } from './assertTestCases';
 
-const testCases: [property: string, value: string, expect: CSSDeclaration[]][] = [
+const testCases: [property: string, value: CSSPropertyValue, expect: CSSDeclaration[]][] = [
   ['align-content', 'auto', [
     ['-webkit-align-content', 'auto'],
     ['-ms-flex-line-pack', 'auto'],

--- a/test/util/addVendorPrefixes.test.ts
+++ b/test/util/addVendorPrefixes.test.ts
@@ -39,4 +39,16 @@ describe('util/addVendorPrefixes', () => {
       '-webkit-foo',
     ]);
   });
+
+  it('Prefixes a numeric value', () => {
+    expect(addVendorPrefixes(100, Vendor.moz)).toEqual(['-moz-100']);
+  });
+
+  it('Prefixes a null value', () => {
+    expect(addVendorPrefixes(null, Vendor.moz)).toEqual(['-moz-']);
+  });
+
+  it('Prefixes an undefined value', () => {
+    expect(addVendorPrefixes(undefined, Vendor.moz)).toEqual(['-moz-']);
+  });
 });

--- a/test/util/isVendorPrefixed.test.ts
+++ b/test/util/isVendorPrefixed.test.ts
@@ -6,6 +6,18 @@ describe('util/isVendorPrefixed', () => {
     expect(isVendorPrefixed('foo')).toBe(false);
   });
 
+  it('Returns false if providing number', () => {
+    expect(isVendorPrefixed(100)).toBe(false);
+  });
+
+  it('Returns false if providing null', () => {
+    expect(isVendorPrefixed(null)).toBe(false);
+  });
+
+  it('Returns false if providing undefined', () => {
+    expect(isVendorPrefixed(undefined)).toBe(false);
+  });
+
   it('Returns true if vendor prefixed', () => {
     const prefixes = Object.keys(vendorPrefixes).map(
       (vendor) => vendorPrefixes[vendor as keyof typeof vendorPrefixes],


### PR DESCRIPTION
Implementing libraries / frameworks may choose to provide values as null, undefined, numeric, or other arbitrary primitives. In the interest of compatibility, let's mark values as unknown and ensure our plugin functions must handle whatever's thrown at them.